### PR TITLE
Small tweaks: use ssl, url fix, check return code.

### DIFF
--- a/src/create_session.py
+++ b/src/create_session.py
@@ -1,11 +1,11 @@
 import requests
 
 
-def create_json_session(web_host, username, password):
+def create_json_session(web_host, username, password, verify=True):
     session = requests.Session()
     # Start by getting supported versions from the base url...
     api_url = '%s/api/' % web_host
-    r = session.get(api_url, verify=False)
+    r = session.get(api_url, verify=verify)
     print(api_url,r)
     # we get a list of versions
     versions = r.json()['data']

--- a/src/retrieve_image.py
+++ b/src/retrieve_image.py
@@ -14,8 +14,11 @@ def retrieve_image(session, base_url, img_id, scale):
     # calculate width to be requested based on metadata and the specified scale factor
     width = int(thisjson['data']['Pixels']['SizeX'])
     scaled = round(width/scale)
-    img_address = host+"/webgateway/render_birds_eye_view/"+str(img_id)+"/"+str(scaled)
+    img_address = host+"/webgateway/render_birds_eye_view/"+str(img_id)+"/"+str(scaled)+"/"
     jpeg = session.get(img_address, stream=True)
+
+    if jpeg.status_code != 200:
+        raise Exception("Received response {} with content: {}".format(jpeg.status_code, jpeg.content))
 
     # using PIL and BytesIO to open the request content as an image
     i = Image.open(BytesIO(jpeg.content))


### PR DESCRIPTION
A few small tweaks:
* By default, verify SSL. Can be disabled with verify=False
* Add a "/" to the image fetching URL, avoiding a needless redirect from omero-web
* Check return code. If it's not 200, throw an exception rather than pass result string to Pillow